### PR TITLE
Add CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ katt.run {scenario, params}, (err, result ) ->
     * `validate` to be called async with `actual`, `expected`, `params`, `callbacks`
 
 
+## CLI
+
+```shell
+katt-js -p '{"hostname":"httpbin.org","your_name":"Klarna","my_name":"KATT","whoarewe":"Klarna_and_KATT"}' doc/example-httpbin.apib
+```
+
+
 ## Contributing
 
 A pull-request is most welcome. Please make sure that the following criteria are

--- a/bin/cli.coffee
+++ b/bin/cli.coffee
@@ -1,0 +1,59 @@
+#!/usr/bin/env coffee
+# Copyright 2013 Klarna AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+fs = require 'fs'
+argparse = require 'argparse'
+_ = require 'lodash'
+katt = require '../'
+pkg = require '../package'
+test = require 'tape'
+
+parseArgs = (args) ->
+  ArgumentParser = argparse.ArgumentParser
+
+  parser = new ArgumentParser
+    description: pkg.description
+    version: pkg.version
+    addHelp: true
+
+  parser.addArgument ['-p', '--params'],
+    help: 'Params as JSON string'
+    nargs: '1'
+
+  parser.addArgument ['scenarios'],
+    help: 'Scenarios as files'
+    nargs: '+'
+
+  parser.parseArgs args
+
+
+exports.createTest = (scenario, params = {}) ->
+  params = _.cloneDeep params
+  test scenario, (t) ->
+    katt.run {scenario, params}, (err, result) ->
+      if err?
+        return t.error err
+      t.equal result.status, 'pass', JSON.stringify result, null, 2
+      t.end()
+
+
+main = exports.main = (args = process.args) ->
+  args = parseArgs args
+  {params, scenarios} = args
+  params = JSON.parse params  if params?
+  exports.createTest scenario, params  for scenario in scenarios
+
+
+main()  if require.main is module

--- a/package.json
+++ b/package.json
@@ -20,13 +20,18 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
+  "bin": {
+    "katt-js": "bin/cli.coffee"
+  },
   "scripts": {
     "prepublish": "make prepublish",
     "test": "make test"
   },
   "dependencies": {
     "katt-blueprint-parser": "~1.1.2",
-    "lodash": "~1.3.1"
+    "lodash": "~1.3.1",
+    "argparse": "~0.1.15",
+    "tape": "~2.12.3"
   },
   "optionalDependencies": {
     "coffee-script": "~1.6.3",
@@ -42,6 +47,9 @@
     "testem": "~0.3.18"
   },
   "publishConfig": {
+    "bin": {
+      "katt-js": "bin/cli.js"
+    },
     "optionalDependencies": {}
   }
 }


### PR DESCRIPTION
When the API test is simple (i.e. requires no setup), it's useful to be able to run the test from the CLI.
