### PR TITLE
Expected but undefined

### DIFF
--- a/src/validate.coffee
+++ b/src/validate.coffee
@@ -33,7 +33,7 @@ exports.validate = ({key, actual, expected, params, callbacks, errors}) ->
     return errors
   expected = exports.store {actual, expected, params, callbacks}
   # expected = callbacks.recall {syntax: 'text', expected, params, callbacks}
-  if actual?
+  if actual isnt undefined
     return errors  if actual is expected
     reason = 'not_equal'
     reason = 'unexpected'  if Const.unexpectedRE.test expected

--- a/src/validate.coffee
+++ b/src/validate.coffee
@@ -33,9 +33,12 @@ exports.validate = ({key, actual, expected, params, callbacks, errors}) ->
     return errors
   expected = exports.store {actual, expected, params, callbacks}
   # expected = callbacks.recall {syntax: 'text', expected, params, callbacks}
-  return errors  if actual is expected
-  reason = 'not_equal'
-  reason = 'unexpected'  if Const.unexpectedRE.test expected
+  if actual?
+    return errors  if actual is expected
+    reason = 'not_equal'
+    reason = 'unexpected'  if Const.unexpectedRE.test expected
+  else
+    reason = 'not_equal'
   errors.push {
     reason
     key

--- a/src/validate.coffee
+++ b/src/validate.coffee
@@ -38,6 +38,7 @@ exports.validate = ({key, actual, expected, params, callbacks, errors}) ->
     reason = 'not_equal'
     reason = 'unexpected'  if Const.unexpectedRE.test expected
   else
+    return errors  if Const.unexpectedRE.test expected
     reason = 'not_equal'
   errors.push {
     reason

--- a/test/katt.coffee
+++ b/test/katt.coffee
@@ -64,3 +64,12 @@ describe 'katt', () ->
         done()
 
     it 'should run and fail on unexpected disallow'
+
+    it 'should run and fail on expected-but-undefined', (done) ->
+      scenario = '/mock/expected-but-undefined.apib'
+      katt.run {scenario}, (err, result) ->
+        result.status.should.eql 'fail'
+        errors = result.transactionResults[0].errors
+        errors[0].key.should.eql '/body/expected'
+        errors[0].reason.should.eql 'not_equal'
+        done()

--- a/test/katt.coffee
+++ b/test/katt.coffee
@@ -73,3 +73,9 @@ describe 'katt', () ->
         errors[0].key.should.eql '/body/expected'
         errors[0].reason.should.eql 'not_equal'
         done()
+
+    it 'should run a scenario with unexpected-and-undefined', (done) ->
+      scenario = '/mock/unexpected-and-undefined.apib'
+      katt.run {scenario}, (err, result) ->
+        result.status.should.eql 'pass'
+        done()

--- a/test/katt.fixtures.coffee
+++ b/test/katt.fixtures.coffee
@@ -31,6 +31,7 @@ exports.run.before = () ->
     return fsTest3  if filename is '/mock/api-mismatch.apib'
     return fsTest4  if filename is '/mock/unexpected-disallow.apib'
     return fsTest5  if filename is '/mock/expected-but-undefined.apib'
+    return fsTest6  if filename is '/mock/unexpected-and-undefined.apib'
     fs.readFileSync.apply fs, arguments
   mockery.registerMock 'fs', fsMock
   mockery.enable
@@ -115,6 +116,11 @@ exports.run.before = () ->
   # Mock response for unexpected disallow test
   nock('http://127.0.0.1')
     .get('/expected-but-undefined')
+    .reply 200, JSON.stringify({}, null, 4), 'Content-Type': 'application/json'
+
+  # Mock response for unexpected disallow test
+  nock('http://127.0.0.1')
+    .get('/unexpected-and-undefined')
     .reply 200, JSON.stringify({}, null, 4), 'Content-Type': 'application/json'
 
   {
@@ -282,5 +288,15 @@ GET /expected-but-undefined
 < Content-Type: application/json
 {
     "expected": "{{>defined_value}}"
+}
+"""
+
+fsTest6 = """--- Test 6 ---
+
+GET /unexpected-and-undefined
+< 200
+< Content-Type: application/json
+{
+    "expected": "{{unexpected}}"
 }
 """

--- a/test/katt.fixtures.coffee
+++ b/test/katt.fixtures.coffee
@@ -30,6 +30,7 @@ exports.run.before = () ->
     return fsTest2  if filename is '/mock/test-params.apib'
     return fsTest3  if filename is '/mock/api-mismatch.apib'
     return fsTest4  if filename is '/mock/unexpected-disallow.apib'
+    return fsTest5  if filename is '/mock/expected-but-undefined.apib'
     fs.readFileSync.apply fs, arguments
   mockery.registerMock 'fs', fsMock
   mockery.enable
@@ -110,6 +111,11 @@ exports.run.before = () ->
       },
       extra_array: ['test']
     }, null, 4), 'Content-Type': 'application/json'
+
+  # Mock response for unexpected disallow test
+  nock('http://127.0.0.1')
+    .get('/expected-but-undefined')
+    .reply 200, JSON.stringify({}, null, 4), 'Content-Type': 'application/json'
 
   {
     katt
@@ -266,5 +272,15 @@ GET /unexpected-disallow
         "{{_}}": "{{unexpected}}"
     },
     "extra_array": ["{{unexpected}}"]
+}
+"""
+
+fsTest5 = """--- Test 5 ---
+
+GET /expected-but-undefined
+< 200
+< Content-Type: application/json
+{
+    "expected": "{{>defined_value}}"
 }
 """


### PR DESCRIPTION
I woke up yesterday in a situation of

``` json
{
  "result": "{{>result}}"
}
```

The test was passing, although `result` was undefined.

Given that KATT works on partial matches, I think it should actually fail when it should store a value, and that value is undefined.

What do you think, @isakb?

**UPDATE**: added also a check for the situation where "you _expect_ a value to be _unexpected_ i.e. undefined".
